### PR TITLE
Relax the url specification and allow for domain names

### DIFF
--- a/redsocks
+++ b/redsocks
@@ -21,11 +21,11 @@ EOF
 }
 
 function parse_ip {
-  echo $1 | sed -nE "s/^http(s)?:\/\/([0-9\.]+):([0-9]+)$/\2/p"
+  echo $1 | sed -nE "s/^http(s)?:\/\/(.+):([0-9]+)$/\2/p"
 }
 
 function parse_port {
-  echo $1 | sed -nE "s/^http(s)?:\/\/([0-9\.]+):([0-9]+)$/\3/p"
+  echo $1 | sed -nE "s/^http(s)?:\/\/(.+):([0-9]+)$/\3/p"
 }
 
 


### PR DESCRIPTION
This allows anything to be matched between the http(s):// and the port number
Enables you to use domain names for the proxy servers, redsocks will use the first it finds
