### PR TITLE
Readme changes including the change requested in issue #4 "Need to change image name from redsocks to munkyboy/redsocks in docker run command"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ iptables -t nat -D PREROUTING -p tcp --dport 443 -j REDIRECT --to 12346
 
 #### Caveats
 The container is sharing the Docker host's network and is listening to port `12345` and `12346`. If this port is already in use, you might need to start the docker container without `--net=host` switch, but with a port mapping instead, e.g.
-```
+<pre>
 export my_proxy=http://yourproxy_IP_address_or_name:8080
-docker run -p 54321:12345 -p 64321:12346 -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
+docker run -p <b>54321</b>:12345 -p <b>64321</b>:12346 -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
 unset my_proxy
-```
+</pre>
 In this case the you need to redirect your traffic to the mapped port (`54321` in this example), e.g. 
-```
-iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 54321
-iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to 64321
-```
+<pre>
+iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to <b>54321</b>
+iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to <b>64321</b>
+</pre>
 The container cannot be not aware of this port mapping and therefore it will try confusing you with iptable examples with ports `12345` and `12346`.
 :blush:
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ specific ports 80 and 443 to the redsocks daemon (see below).
 ### Start Container
 
 #### Simple Example for HTTP Proxy only
-(Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.)
+Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment:
 ```
 docker run --net=host -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
 ```
 
 #### Example with HTTP proxy and HTTPS Proxy pointing to the same proxy URL
-(Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.)
+Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment:
 ```
 export my_proxy=http://yourproxy_IP_address_or_name:8080
 docker run --net=host -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks

--- a/README.md
+++ b/README.md
@@ -5,14 +5,25 @@ https://github.com/wtsi-hgi/docker-proxify
 
 This container requires that you link the host network stack to the container.
 After starting the container, you will then issue iptable commands to redirect
-specific ports to the redsocks daemon.
+specific ports 80 and 443 to the redsocks daemon.
 
 to run:
 
 ```
-docker run --net=host -e http_proxy=http://yourproxy.company.com:8080 -e https_proxy=http://yourproxy.company.com:8080 munkyboy/redsocks
+docker run --net=host -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
+```
+Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.
+
+Example with HTTP proxy and HTTPS Proxy:
+
+```
+export my_proxy=http://yourproxy_IP_address_or_name:8080
+docker run --net=host -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
+unset my_proxy
 ```
 
-The container currently interprets the environment variables `http_proxy` and
-`https_proxy` to configure redsocks. Upon starting, the start script will echo
-sample `iptables` commands to issue on the host.
+Upon starting, the start script will echo sample `iptables` commands that need to be issued on the Docker host, e.g. 
+```
+iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 12345
+```
+As you see, the redosocks deamon is listening to port `12345`. 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ specific ports 80 and 443 to the redsocks daemon (see below).
 ```
 docker run --net=host -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
 ```
-Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.
 
-#### Example with HTTP proxy and HTTPS Proxy pointing to the same proxy URL:
+#### Example with HTTP proxy and HTTPS Proxy pointing to the same proxy URL
 (Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.)
 ```
 export my_proxy=http://yourproxy_IP_address_or_name:8080
@@ -30,22 +29,27 @@ unset my_proxy
 Upon starting, the start script will echo sample `iptables` commands that need to be issued on the Docker host, e.g. 
 ```
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 12345
+iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to 12346
 ```
-After you stop the container, you will need to cleanup the iptables rules:
+After you stop the container, you will need to cleanup the iptables rules again:
 ```
 iptables -t nat -D PREROUTING -p tcp --dport 80 -j REDIRECT --to 12345
+iptables -t nat -D PREROUTING -p tcp --dport 443 -j REDIRECT --to 12346
 ```
 
 #### Caveats
-The container is sharing the Docker host's network and is listening to port `12345`. If this port is already in use, you might need to start the docker container without `--net=host` switch, but with a port mapping instead, e.g.
+The container is sharing the Docker host's network and is listening to port `12345` and `12346`. If this port is already in use, you might need to start the docker container without `--net=host` switch, but with a port mapping instead, e.g.
 ```
-docker run -p54321:12345 -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
+export my_proxy=http://yourproxy_IP_address_or_name:8080
+docker run -p 54321:12345 -p 64321:12346 -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
+unset my_proxy
 ```
 In this case the you need to redirect your traffic to the mapped port (`54321` in this example), e.g. 
 ```
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 54321
+iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to 64321
 ```
-The container cannot be not aware of this port mapping and therefore it will try confusing you with iptable examples with port `12345`.
+The container cannot be not aware of this port mapping and therefore it will try confusing you with iptable examples with ports `12345` and `12346`.
 :blush:
 
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ After starting the container, you will then issue iptable commands to redirect
 specific ports to the redsocks daemon.
 
 to run:
+
 ```
-docker run --net=host -e http_proxy=http://1.2.3.4:3128 redsocks
+docker run --net=host -e http_proxy=http://yourproxy.company.com:8080 -e https_proxy=http://yourproxy.company.com:8080 munkyboy/redsocks
 ```
 
 The container currently interprets the environment variables `http_proxy` and

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and 
 ```
 docker run --net=host -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
 ```
+or if want to restrict the container to have access to port **`12345`** only (i.e. the one that are used by redsocks for HTTP):
+<pre>
+docker run -p <b>12345</b>:12345 -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
+</pre>
 
 #### Example with HTTP proxy and HTTPS Proxy pointing to the same proxy URL
 Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment:
@@ -24,6 +28,10 @@ export my_proxy=http://yourproxy_IP_address_or_name:8080
 docker run --net=host -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
 unset my_proxy
 ```
+or if want to restrict the container to have access to ports **`12345`** and **`12346`** only (i.e. the ones that are used by redsocks for HTTP and HTTPS) you need to replace the second command by:
+<pre>
+docker run -p <b>12345</b>:12345 -p <b>12346</b>:12346 e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
+</pre>
 
 #### Redirection on the Docker Host
 Upon starting, the start script will echo sample `iptables` commands that need to be issued on the Docker host, e.g. 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,51 @@
 A redsocks container primarily used to transparently utilize http(s) proxies.
 
-Inspired by https://github.com/jpetazzo/squid-in-a-can and
-https://github.com/wtsi-hgi/docker-proxify
+Fork of [munkyboy's docker-redsocks repository](https://github.com/munkyboy/docker-redsocks) in order to improve the documentation (at least, I will try).
+
+Inspired by [https://github.com/jpetazzo/squid-in-a-can](https://github.com/jpetazzo/squid-in-a-can) and
+[https://github.com/wtsi-hgi/docker-proxify](https://github.com/wtsi-hgi/docker-proxify).
 
 This container requires that you link the host network stack to the container.
 After starting the container, you will then issue iptable commands to redirect
-specific ports 80 and 443 to the redsocks daemon.
+specific ports 80 and 443 to the redsocks daemon (see below).
 
-to run:
+### Start Container
 
+#### Simple Example for HTTP Proxy only
+(Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.)
 ```
 docker run --net=host -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
 ```
 Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.
 
-Example with HTTP proxy and HTTPS Proxy pointing to the same proxy URL:
-
+#### Example with HTTP proxy and HTTPS Proxy pointing to the same proxy URL:
+(Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.)
 ```
 export my_proxy=http://yourproxy_IP_address_or_name:8080
 docker run --net=host -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
 unset my_proxy
 ```
 
+#### Redirection on the Docker Host
 Upon starting, the start script will echo sample `iptables` commands that need to be issued on the Docker host, e.g. 
 ```
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 12345
 ```
-As you see, the redosocks deamon is listening to port `12345`. 
+After you stop the container, you will need to cleanup the iptables rules:
+```
+iptables -t nat -D PREROUTING -p tcp --dport 80 -j REDIRECT --to 12345
+```
+
+#### Caveats
+The container is sharing the Docker host's network and is listening to port `12345`. If this port is already in use, you might need to start the docker container without `--net=host` switch, but with a port mapping instead, e.g.
+```
+docker run -p54321:12345 -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
+```
+In this case the you need to redirect your traffic to the mapped port (`54321` in this example), e.g. 
+```
+iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 54321
+```
+The container cannot be not aware of this port mapping and therefore it will try confusing you with iptable examples with port `12345`.
+:blush:
+
+

--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and 
 ```
 docker run --net=host -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
 ```
-or if want to restrict the container to have access to port **`12345`** only (i.e. the one that are used by redsocks for HTTP):
-<pre>
-docker run -p <b>12345</b>:12345 -e http_proxy=http://yourproxy_IP_address_or_name:8080 munkyboy/redsocks
-</pre>
 #### Example with HTTP proxy and HTTPS Proxy pointing to the same proxy URL
 Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment:
 ```
@@ -27,7 +23,6 @@ export my_proxy=http://yourproxy_IP_address_or_name:8080
 docker run --net=host -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
 unset my_proxy
 ```
-Here, the `-p` way of running the docker container is not possible (see Caveats section).
 
 #### Redirection on the Docker Host
 Upon starting, the start script will echo sample `iptables` commands that need to be issued on the Docker host, e.g. 
@@ -42,18 +37,10 @@ iptables -t nat -D PREROUTING -p tcp --dport 443 -j REDIRECT --to 12346
 ```
 
 #### Caveats
-The container is sharing the Docker host's network and is listening to port `12345` and `12346`. If port `12345`is already in use, you can start the docker container without `--net=host` switch, but with a port mapping instead, e.g.
-<pre>
-export my_proxy=http://yourproxy_IP_address_or_name:8080
-docker run -p <b>54321</b>:12345 -e http_proxy=$my_proxy -e https_proxy=$my_proxy munkyboy/redsocks
-unset my_proxy
-</pre>
-In this case the you need to redirect your traffic to the mapped port (`54321` in this example), e.g. 
-<pre>
-iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to <b>54321</b>
-</pre>
-The container cannot be not aware of this port mapping and therefore it will try confusing you with iptable examples with ports `12345`.
-:blush:
-Note, that the `-p` way or running the container does not work with HTTPS: SSL does like if the redsocks internal view of the IP address differs from the external view, and we are forced to use the `--net=host` configuration.
+The container is sharing the Docker host's network and is listening to port `12345` and `12346`. If one of those ports is already in use, you will not be able to start the container. In a HTTP-only case, you may use a port mapping like
+```
+docker run -p 54321:12345 ...
+```
+instead of `docker run --net=host ...`. However, this is not possible in case of HTTPS, since the container needs to share the network IP address of the host, if you do not want to get an SSL error (`403 Forbidden`).
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker run --net=host -e http_proxy=http://yourproxy_IP_address_or_name:8080 mun
 ```
 Change `http://yourproxy_IP_address_or_name:8080` by the IP address or name and TCP port that fits to your environment and add -e https_proxy, if needed.
 
-Example with HTTP proxy and HTTPS Proxy:
+Example with HTTP proxy and HTTPS Proxy pointing to the same proxy URL:
 
 ```
 export my_proxy=http://yourproxy_IP_address_or_name:8080


### PR DESCRIPTION
Hi munkyboy,
here again: a PR for cherry-picking. However, it might not be easy to find the right commit in this mess.
:blush:

The minimum I see is to change the docker run command from "redsocks" to "munkyboy/redsocks". This is done in the first commit, but I had added the `-e https_proxy ...` at the same time, and the `docker run` command got a little bit too long for my taste. It is also O.K., if you just change "redsocks" to "munkyboy/redsocks", I guess.
Thanks,
Oliver
